### PR TITLE
exclude edit-farmer staff check until RC3

### DIFF
--- a/controllers/farmer/updateFarmer.js
+++ b/controllers/farmer/updateFarmer.js
@@ -28,43 +28,44 @@ const updateFarmer = async (req, res, next) => {
         })
       );
     }
-    if (farmer.staff === username || isAdmin) {
-      if (isAdmin) {
-        const convertedObject = convertToDotNotationObject(farmerDetails);
-        const updatedFarmer = await models.Farmer.findOneAndUpdate(
-          { _id: farmerId },
-          convertedObject,
-          { new: true, runValidators: true }
-        );
 
-        return res.status(201).json({
-          success: true,
-          message: 'Farmer details updated successfully',
-          farmer: updatedFarmer
-        });
-      }
-
-      const farmerEditRequest = await models.ChangeRequest.create({
-        requested_changes: farmerDetails,
-        farmer_id: farmerId,
-        farmer_name: `${farmer.personalInfo.first_name} ${farmer.personalInfo.surname}`,
-        change_requested_by: username,
-        date: Date.now()
-      });
+    if (isAdmin) {
+      const convertedObject = convertToDotNotationObject(farmerDetails);
+      const updatedFarmer = await models.Farmer.findOneAndUpdate(
+        { _id: farmerId },
+        convertedObject,
+        { new: true, runValidators: true }
+      );
 
       return res.status(201).json({
         success: true,
-        message:
-          'You are not an admin, your change was created and is ready for admin approval',
-        farmerEditRequest
+        message: 'Farmer details updated successfully',
+        farmer: updatedFarmer
       });
     }
-    return next(
+    /* This is implemented in RC3
+      if (farmer.staff === username) { */
+    const farmerEditRequest = await models.ChangeRequest.create({
+      requested_changes: farmerDetails,
+      farmer_id: farmerId,
+      farmer_name: `${farmer.personalInfo.first_name} ${farmer.personalInfo.surname}`,
+      change_requested_by: username,
+      date: Date.now()
+    });
+
+    return res.status(201).json({
+      success: true,
+      message:
+        'You are not an admin, your change was created and is ready for admin approval',
+      farmerEditRequest
+    });
+
+    /* return next(
       createError({
         message: 'Not authorized to update farmer details',
         status: NOT_FOUND
       })
-    );
+    ); */
   } catch (err) {
     return next(
       createError({

--- a/controllers/farmer/updateFarmer.js
+++ b/controllers/farmer/updateFarmer.js
@@ -56,7 +56,7 @@ const updateFarmer = async (req, res, next) => {
     return res.status(201).json({
       success: true,
       message:
-        'You are not an admin, your change was created and is ready for admin approval',
+        'Your change was created and is ready for admin approval',
       farmerEditRequest
     });
 

--- a/tests/changeRequest.test.js
+++ b/tests/changeRequest.test.js
@@ -62,7 +62,7 @@ describe('Request change route', () => {
       .end(async (err, res) => {
         res.should.have.status(201);
         res.body.message.should.equal(
-          'You are not an admin, your change was created and is ready for admin approval'
+          'Your change was created and is ready for admin approval'
         );
         const changeRequests = await models.ChangeRequest.find();
         chai.expect(changeRequests).to.have.lengthOf(1);

--- a/tests/changeRequest.test.js
+++ b/tests/changeRequest.test.js
@@ -119,7 +119,7 @@ describe('Request change route', () => {
       .end(async (err, res) => {
         res.should.have.status(201);
         res.body.message.should.equal(
-          'You are not an admin, your change was created and is ready for admin approval'
+          'Your change was created and is ready for admin approval'
         );
         const changeRequests = await models.ChangeRequest.find();
         chai.expect(changeRequests).to.have.lengthOf(1);

--- a/tests/farmers.test.js
+++ b/tests/farmers.test.js
@@ -84,7 +84,7 @@ describe('Farmer route', () => {
       .end((err, res) => {
         res.should.have.status(201);
         res.body.message.should.equal(
-          'You are not an admin, your change was created and is ready for admin approval'
+          'Your change was created and is ready for admin approval'
         );
         done(err);
       });


### PR DESCRIPTION
# Description

Exclude theedit staff check from the update farmer controller

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works AND the tests pass
