### PR TITLE
Don't change archived farmers

### DIFF
--- a/controllers/changeRequest/approveChangeRequest.js
+++ b/controllers/changeRequest/approveChangeRequest.js
@@ -1,5 +1,5 @@
 const { models } = require('../../models');
-const { createError, GENERIC_ERROR } = require('../../helpers/error.js');
+const { createError, GENERIC_ERROR, FORBIDDEN  } = require('../../helpers/error.js');
 const convertToDotNotationObject = require('../farmer/convertToDotNotationObject');
 
 /**
@@ -15,16 +15,37 @@ const approveChangeRequest = async (req, res, next) => {
     const changeRequestEntry = await models.ChangeRequest.findOne({
       _id: req.params.id
     });
+
     if (changeRequestEntry) {
       const convertedObject = convertToDotNotationObject(
         changeRequestEntry.requested_changes
       );
+
+      const farmer = await models.Farmer.findOne({ _id: changeRequestEntry.farmer_id });
+      if (!farmer) {
+        return next(
+          createError({
+            message: 'Farmer does not exist',
+            status: NOT_FOUND
+          })
+        );
+      }
+
+      if(farmer.archived){
+        return next({
+          message: 'This Farmer is archived and can not be updated',
+          status: FORBIDDEN
+       })
+      }
+
       await models.Farmer.findOneAndUpdate(
         { _id: changeRequestEntry.farmer_id },
         convertedObject,
         { new: true, runValidators: true }
       );
+
       await models.ChangeRequest.findOneAndRemove({ _id: req.params.id });
+
       return res.status(200).json({
         success: true,
         message: 'ChangeRequest approved',
@@ -34,7 +55,7 @@ const approveChangeRequest = async (req, res, next) => {
     return res.status(404).json({
       success: false,
       message:
-        'There is no saved changeRequest with this ID, please subit a valid changeRequest-ID'
+        'There is no saved changeRequest with this ID, please submit a valid changeRequest-ID'
     });
   } catch (err) {
     return next(

--- a/controllers/changeRequest/approveChangeRequest.js
+++ b/controllers/changeRequest/approveChangeRequest.js
@@ -21,7 +21,8 @@ const approveChangeRequest = async (req, res, next) => {
         changeRequestEntry.requested_changes
       );
 
-      const farmer = await models.Farmer.findOne({ _id: changeRequestEntry.farmer_id });
+      const farmer = await models.Farmer.findOne({ _id: changeRequestEntry.farmer_id }).lean();
+
       if (!farmer) {
         return next(
           createError({
@@ -32,6 +33,7 @@ const approveChangeRequest = async (req, res, next) => {
       }
 
       if(farmer.archived){
+        await models.ChangeRequest.findOneAndRemove({ _id: req.params.id });
         return next({
           message: 'This Farmer is archived and can not be updated',
           status: FORBIDDEN

--- a/controllers/farmer/updateFarmer.js
+++ b/controllers/farmer/updateFarmer.js
@@ -3,6 +3,7 @@ const convertToDotNotationObject = require('./convertToDotNotationObject');
 const {
   createError,
   GENERIC_ERROR,
+  FORBIDDEN,
   NOT_FOUND
 } = require('../../helpers/error');
 
@@ -27,6 +28,13 @@ const updateFarmer = async (req, res, next) => {
           status: NOT_FOUND
         })
       );
+    }
+    
+    if(farmer.archived){
+      return next({
+        message: "This Farmer is archived and can not be updated",
+        status: FORBIDDEN
+      })
     }
 
     if (isAdmin) {

--- a/controllers/farmer/updateFarmer.js
+++ b/controllers/farmer/updateFarmer.js
@@ -29,10 +29,10 @@ const updateFarmer = async (req, res, next) => {
         })
       );
     }
-    
+
     if(farmer.archived){
       return next({
-        message: "This Farmer is archived and can not be updated",
+        message: 'This Farmer is archived and can not be updated',
         status: FORBIDDEN
       })
     }

--- a/tests/farmers.test.js
+++ b/tests/farmers.test.js
@@ -120,6 +120,33 @@ describe('Farmer route', () => {
         done(err);
       });
   });
+  it('It does not update archived farmer details when done by admin', (done) => {
+    farmerInput.personalInfo.title = 'Chief';
+    chai
+      .request(server)
+      .patch(`/api/v1/farmers/${id}/update`)
+      .set('Authorization', token)
+      .send(farmerInput)
+      .end((err, res) => {
+        res.should.have.status(403);
+        res.body.message.should.equal('This Farmer is archived and can not be updated');
+        done(err);
+      });
+  });
+  it('It does not update archived farmer details if done by staff', (done) => {
+    farmerInput.personalInfo.title = 'Chief';
+    
+    chai
+      .request(server)
+      .patch(`/api/v1/farmers/${idCreatedByStaff}/update`)
+      .set('Authorization', staffToken)
+      .send(farmerInput)
+      .end((err, res) => {
+        res.should.have.status(403);
+        res.body.message.should.equal('This Farmer is archived and can not be updated');
+        done(err);
+      });
+  });
   it('It should return 404 if there are no farmers in the DB', (done) => {
     chai
       .request(server)


### PR DESCRIPTION
# Description

Previosly archived farmers could be updated by approving stale change requests. This PR canges that. If stale Requests are approved, the backend automatically declines and removes them.

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works AND the tests pass
