### PR TITLE
Fix empty update bug

### DIFF
--- a/controllers/changeRequest/approveChangeRequest.js
+++ b/controllers/changeRequest/approveChangeRequest.js
@@ -15,7 +15,6 @@ const approveChangeRequest = async (req, res, next) => {
     const changeRequestEntry = await models.ChangeRequest.findOne({
       _id: req.params.id
     });
-    
     if (changeRequestEntry) {
       const convertedObject = convertToDotNotationObject(
         changeRequestEntry.requested_changes

--- a/controllers/changeRequest/approveChangeRequest.js
+++ b/controllers/changeRequest/approveChangeRequest.js
@@ -15,6 +15,10 @@ const approveChangeRequest = async (req, res, next) => {
     const changeRequestEntry = await models.ChangeRequest.findOne({
       _id: req.params.id
     });
+    if(changeRequestEntry.requested_changes === {}){
+      await models.ChangeRequest.findOneAndRemove({ _id: req.params.id });
+      return res.status(200).json({ message: 'The change requestw as empty and has been removed' });
+    }
     if (changeRequestEntry) {
       const convertedObject = convertToDotNotationObject(
         changeRequestEntry.requested_changes

--- a/controllers/changeRequest/approveChangeRequest.js
+++ b/controllers/changeRequest/approveChangeRequest.js
@@ -15,10 +15,7 @@ const approveChangeRequest = async (req, res, next) => {
     const changeRequestEntry = await models.ChangeRequest.findOne({
       _id: req.params.id
     });
-    if(changeRequestEntry.requested_changes === {}){
-      await models.ChangeRequest.findOneAndRemove({ _id: req.params.id });
-      return res.status(200).json({ message: 'The change requestw as empty and has been removed' });
-    }
+    
     if (changeRequestEntry) {
       const convertedObject = convertToDotNotationObject(
         changeRequestEntry.requested_changes

--- a/controllers/farmer/updateFarmer.js
+++ b/controllers/farmer/updateFarmer.js
@@ -3,7 +3,8 @@ const convertToDotNotationObject = require('./convertToDotNotationObject');
 const {
   createError,
   GENERIC_ERROR,
-  NOT_FOUND
+  NOT_FOUND,
+  FORBIDDEN
 } = require('../../helpers/error');
 
 /**
@@ -27,6 +28,14 @@ const updateFarmer = async (req, res, next) => {
           status: NOT_FOUND
         })
       );
+    }
+
+    if(farmerDetails === {}){
+      await models.ChangeRequest.findOneAndRemove({ _id: req.params.id });
+      return next({
+        status: FORBIDDEN,
+        message: 'You can not submit empty updates'
+      })
     }
 
     if (isAdmin) {

--- a/controllers/farmer/updateFarmer.js
+++ b/controllers/farmer/updateFarmer.js
@@ -30,8 +30,7 @@ const updateFarmer = async (req, res, next) => {
       );
     }
 
-    if(farmerDetails === {}){
-      await models.ChangeRequest.findOneAndRemove({ _id: req.params.id });
+    if(Object.keys(farmerDetails).length === 0 && farmerDetails.constructor === Object){
       return next({
         status: FORBIDDEN,
         message: 'You can not submit empty updates'

--- a/controllers/farmer/updateFarmer.js
+++ b/controllers/farmer/updateFarmer.js
@@ -5,7 +5,6 @@ const {
   GENERIC_ERROR,
   NOT_FOUND,
   FORBIDDEN
-
 } = require('../../helpers/error');
 
 /**
@@ -27,23 +26,28 @@ const updateFarmer = async (req, res, next) => {
         createError({
           message: 'Farmer does not exist',
           status: NOT_FOUND
-        });
+        })
       );
     }
 
-    if(Object.keys(farmerDetails).length === 0 && farmerDetails.constructor === Object){
-      return next(createError({
-        status: FORBIDDEN,
-        message: 'You can not submit empty updates'
-        });
+    if (
+      Object.keys(farmerDetails).length === 0 &&
+      farmerDetails.constructor === Object
+    ) {
+      return next(
+        createError({
+          status: FORBIDDEN,
+          message: 'You can not submit empty updates'
+        })
       );
     }
-        
-    if(farmer.archived){
-      return next(createError({
-        message: 'This Farmer is archived and can not be updated',
-        status: FORBIDDEN
-        });
+
+    if (farmer.archived) {
+      return next(
+        createError({
+          message: 'This Farmer is archived and can not be updated',
+          status: FORBIDDEN
+        })
       );
     }
 
@@ -73,8 +77,7 @@ const updateFarmer = async (req, res, next) => {
 
     return res.status(201).json({
       success: true,
-      message:
-        'Your change was created and is ready for admin approval',
+      message: 'Your change was created and is ready for admin approval',
       farmerEditRequest
     });
 

--- a/tests/farmers.test.js
+++ b/tests/farmers.test.js
@@ -1,22 +1,22 @@
-const chai = require('chai');
-const chaiHttp = require('chai-http');
-const server = require('../index');
-const farmerInput = require('./farmerInput');
-const seeds = require('./testsSetup');
+const chai = require("chai");
+const chaiHttp = require("chai-http");
+const server = require("../index");
+const farmerInput = require("./farmerInput");
+const seeds = require("./testsSetup");
 
 chai.should();
 
 chai.use(chaiHttp);
 
-describe('Farmer route', () => {
-  let token = '';
-  let staffToken = '';
-  let id = '';
-  let idCreatedByStaff = '';
-  it('Login admin user responds with 200', (done) => {
+describe("Farmer route", () => {
+  let token = "";
+  let staffToken = "";
+  let id = "";
+  let idCreatedByStaff = "";
+  it("Login admin user responds with 200", done => {
     chai
       .request(server)
-      .post('/api/v1/user/login')
+      .post("/api/v1/user/login")
       .send(seeds.adminUser)
       .end((err, res) => {
         token = res.body.token;
@@ -25,10 +25,10 @@ describe('Farmer route', () => {
       });
   });
 
-  it('Login staff user responds with 200', (done) => {
+  it("Login staff user responds with 200", done => {
     chai
       .request(server)
-      .post('/api/v1/user/login')
+      .post("/api/v1/user/login")
       .send(seeds.staffUser)
       .end((err, res) => {
         staffToken = res.body.token;
@@ -37,11 +37,11 @@ describe('Farmer route', () => {
       });
   });
 
-  it('It should return 201 when creating new farmer', (done) => {
+  it("It should return 201 when creating new farmer", done => {
     chai
       .request(server)
-      .post('/api/v1/farmers/create')
-      .set('Authorization', token)
+      .post("/api/v1/farmers/create")
+      .set("Authorization", token)
       .send(farmerInput)
       .end((err, res) => {
         res.should.have.status(201);
@@ -49,11 +49,11 @@ describe('Farmer route', () => {
         done(err);
       });
   });
-  it('It should return 201 when creating new farmer by staff user', (done) => {
+  it("It should return 201 when creating new farmer by staff user", done => {
     chai
       .request(server)
-      .post('/api/v1/farmers/create')
-      .set('Authorization', staffToken)
+      .post("/api/v1/farmers/create")
+      .set("Authorization", staffToken)
       .send(farmerInput)
       .end((err, res) => {
         res.should.have.status(201);
@@ -61,123 +61,124 @@ describe('Farmer route', () => {
         done(err);
       });
   });
-  it('It updates farmer details when done by admin', (done) => {
-    farmerInput.personalInfo.title = 'Miss';
+  it("It updates farmer details when done by admin", done => {
+    farmerInput.personalInfo.title = "Miss";
     chai
       .request(server)
       .patch(`/api/v1/farmers/${id}/update`)
-      .set('Authorization', token)
+      .set("Authorization", token)
       .send(farmerInput)
       .end((err, res) => {
         res.should.have.status(201);
-        res.body.farmer.personalInfo.title.should.equal('Miss');
+        res.body.farmer.personalInfo.title.should.equal("Miss");
         done(err);
       });
   });
-  it('It does not update farmer details if done by staff', (done) => {
-    farmerInput.personalInfo.title = 'Mr';
+  it("It does not update farmer details if done by staff", done => {
+    farmerInput.personalInfo.title = "Mr";
     chai
       .request(server)
       .patch(`/api/v1/farmers/${idCreatedByStaff}/update`)
-      .set('Authorization', staffToken)
+      .set("Authorization", staffToken)
       .send(farmerInput)
       .end((err, res) => {
         res.should.have.status(201);
         res.body.message.should.equal(
-          'Your change was created and is ready for admin approval'
+          "Your change was created and is ready for admin approval"
         );
         done(err);
       });
   });
-  it('It does not update farmer details if change {} is empty', (done) => {
+  it("It does not update farmer details if change {} is empty", done => {
     chai
       .request(server)
       .patch(`/api/v1/farmers/${idCreatedByStaff}/update`)
-      .set('Authorization', staffToken)
+      .set("Authorization", staffToken)
       .send({})
       .end((err, res) => {
-        console.log(res.body);
         res.should.have.status(403);
-        res.body.message.should.equal(
-          'You can not submit empty updates'
-        );
+        res.body.message.should.equal("You can not submit empty updates");
         done(err);
       });
   });
-  
-  it('It should return a single farmer', (done) => {
+
+  it("It should return a single farmer", done => {
     chai
       .request(server)
       .get(`/api/v1/farmers/${id}`)
-      .set('Authorization', token)
+      .set("Authorization", token)
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.should.be.a('object');
-        res.body.message.should.equal('Farmer record found');
+        res.body.should.be.a("object");
+        res.body.message.should.equal("Farmer record found");
         done(err);
       });
   });
-  it('It deletes farmer details', (done) => {
+  it("It deletes farmer details", done => {
     chai
       .request(server)
       .delete(`/api/v1/farmers/${id}/delete`)
-      .set('Authorization', token)
+      .set("Authorization", token)
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.message.should.equal('Farmer details deleted successfully');
+        res.body.message.should.equal("Farmer details deleted successfully");
       });
     chai
       .request(server)
       .delete(`/api/v1/farmers/${idCreatedByStaff}/delete`)
-      .set('Authorization', token)
+      .set("Authorization", token)
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.message.should.equal('Farmer details deleted successfully');
+        res.body.message.should.equal("Farmer details deleted successfully");
         done(err);
       });
   });
-  it('It does not update archived farmer details when done by admin', (done) => {
-    farmerInput.personalInfo.title = 'Chief';
+  it("It does not update archived farmer details when done by admin", done => {
+    farmerInput.personalInfo.title = "Chief";
     chai
       .request(server)
       .patch(`/api/v1/farmers/${id}/update`)
-      .set('Authorization', token)
+      .set("Authorization", token)
       .send(farmerInput)
       .end((err, res) => {
         res.should.have.status(403);
-        res.body.message.should.equal('This Farmer is archived and can not be updated');
+        res.body.message.should.equal(
+          "This Farmer is archived and can not be updated"
+        );
         done(err);
       });
   });
-  it('It does not update archived farmer details if done by staff', (done) => {
-    farmerInput.personalInfo.title = 'Chief';
-    
+  it("It does not update archived farmer details if done by staff", done => {
+    farmerInput.personalInfo.title = "Chief";
+
     chai
       .request(server)
       .patch(`/api/v1/farmers/${idCreatedByStaff}/update`)
-      .set('Authorization', staffToken)
+      .set("Authorization", staffToken)
       .send(farmerInput)
       .end((err, res) => {
         res.should.have.status(403);
-        res.body.message.should.equal('This Farmer is archived and can not be updated');
+        res.body.message.should.equal(
+          "This Farmer is archived and can not be updated"
+        );
         done(err);
       });
   });
-  it('It should return 404 if there are no farmers in the DB', (done) => {
+  it("It should return 404 if there are no farmers in the DB", done => {
     chai
       .request(server)
       .get(`/api/v1/farmers/${idCreatedByStaff}/`)
-      .set('Authorization', token)
+      .set("Authorization", token)
       .end((err, res) => {
         res.should.have.status(404);
         done(err);
       });
   });
-  it('It should return 201. Duplicate of test at line 40. Need farmer for next test', (done) => {
+  it("It should return 201. Duplicate of test at line 40. Need farmer for next test", done => {
     chai
       .request(server)
-      .post('/api/v1/farmers/create')
-      .set('Authorization', token)
+      .post("/api/v1/farmers/create")
+      .set("Authorization", token)
       .send(farmerInput)
       .end((err, res) => {
         res.should.have.status(201);
@@ -185,35 +186,35 @@ describe('Farmer route', () => {
         done(err);
       });
   });
-  it('It should return an array of farmers', (done) => {
+  it("It should return an array of farmers", done => {
     chai
       .request(server)
-      .get('/api/v1/farmers')
-      .set('Authorization', token)
+      .get("/api/v1/farmers")
+      .set("Authorization", token)
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.farmers.should.be.a('array');
-        res.body.message.should.equal('Farmers records found');
+        res.body.farmers.should.be.a("array");
+        res.body.message.should.equal("Farmers records found");
         done(err);
       });
   });
 
-  it('It should 200 on GET farmer statistics', (done) => {
+  it("It should 200 on GET farmer statistics", done => {
     chai
       .request(server)
-      .get('/api/v1/farmers/statistic')
-      .set('Authorization', token)
+      .get("/api/v1/farmers/statistic")
+      .set("Authorization", token)
       .end((err, res) => {
         res.should.have.status(200);
         done(err);
       });
   });
 
-  it('It should return num of M/F/O farmers that add up to total number of farmers', (done) => {
+  it("It should return num of M/F/O farmers that add up to total number of farmers", done => {
     chai
       .request(server)
-      .get('/api/v1/farmers/statistic')
-      .set('Authorization', token)
+      .get("/api/v1/farmers/statistic")
+      .set("Authorization", token)
       .end((err, res) => {
         const {
           totalNumOfFarmers,
@@ -223,19 +224,19 @@ describe('Farmer route', () => {
         } = res.body;
 
         totalNumOfFarmers.should.equal(
-          totalNumOfMaleFarmers
-            + totalNumOfFemaleFarmers
-            + totalNumOfOtherFarmers
+          totalNumOfMaleFarmers +
+            totalNumOfFemaleFarmers +
+            totalNumOfOtherFarmers
         );
         done(err);
       });
   });
 
-  it('It should return num of <35/>35 y/o farmers that add up to total number of farmers', (done) => {
+  it("It should return num of <35/>35 y/o farmers that add up to total number of farmers", done => {
     chai
       .request(server)
-      .get('/api/v1/farmers/statistic')
-      .set('Authorization', token)
+      .get("/api/v1/farmers/statistic")
+      .set("Authorization", token)
       .end((err, res) => {
         const {
           totalNumOfFarmers,
@@ -244,41 +245,41 @@ describe('Farmer route', () => {
         } = res.body;
 
         totalNumOfFarmers.should.equal(
-          farmersAgeGreaterThanOrEqualThirtyFive
-            + farmersAgeLesserThanThirtyFive
+          farmersAgeGreaterThanOrEqualThirtyFive +
+            farmersAgeLesserThanThirtyFive
         );
         done(err);
       });
   });
 
-  it('It should return 400 bad request and "Not a valid ID" message on bad farmer ID', (done) => {
+  it('It should return 400 bad request and "Not a valid ID" message on bad farmer ID', done => {
     chai
       .request(server)
-      .patch('/api/v1/farmers/hui89ewhee/update')
-      .set('Authorization', token)
+      .patch("/api/v1/farmers/hui89ewhee/update")
+      .set("Authorization", token)
       .send(farmerInput)
       .end((err, res) => {
         res.should.have.status(400);
-        res.body.errors.message.should.equal('Not a valid ID');
+        res.body.errors.message.should.equal("Not a valid ID");
         done(err);
       });
   });
-  it('It should return 400 on failed data validation', (done) => {
-    farmerInput.personalInfo.title = 'Mrzz';
+  it("It should return 400 on failed data validation", done => {
+    farmerInput.personalInfo.title = "Mrzz";
     chai
       .request(server)
-      .post('/api/v1/farmers/create')
-      .set('Authorization', token)
+      .post("/api/v1/farmers/create")
+      .set("Authorization", token)
       .send(farmerInput)
       .end((err, res) => {
         res.should.have.status(400);
         done(err);
       });
   });
-  it('It should return 401 when missing token', (done) => {
+  it("It should return 401 when missing token", done => {
     chai
       .request(server)
-      .post('/api/v1/farmers/create')
+      .post("/api/v1/farmers/create")
       .send(farmerInput)
       .end((err, res) => {
         token = res.body.token;

--- a/tests/farmers.test.js
+++ b/tests/farmers.test.js
@@ -89,6 +89,22 @@ describe('Farmer route', () => {
         done(err);
       });
   });
+  it('It does not update farmer details if change {} is empty', (done) => {
+    chai
+      .request(server)
+      .patch(`/api/v1/farmers/${idCreatedByStaff}/update`)
+      .set('Authorization', staffToken)
+      .send({})
+      .end((err, res) => {
+        console.log(res.body);
+        res.should.have.status(403);
+        res.body.message.should.equal(
+          'You can not submit empty updates'
+        );
+        done(err);
+      });
+  });
+  
   it('It should return a single farmer', (done) => {
     chai
       .request(server)


### PR DESCRIPTION
# Description

Update endpoint does no longer accept empty req.bodies. This is to prevent empty change requests from entering the DB.

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works AND the tests pass
